### PR TITLE
Use 'required_providers' for AWS provider minimum version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
-provider "aws" {
-  version = "= 3.32.0"
-  region  = var.region
-}
-
 resource "aws_eip" "wireguard" {
   vpc = true
   tags = {
@@ -24,7 +15,7 @@ resource "aws_route53_record" "wireguard" {
   ttl             = "60"
   records         = [aws_eip.wireguard.public_ip]
 
-  dynamic geolocation_routing_policy {
+  dynamic "geolocation_routing_policy" {
     for_each = try(length(var.route53_geo.policy) > 0 ? var.route53_geo.policy : tomap(false), {})
 
     content {

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,16 @@
-
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.10"
+
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
 }


### PR DESCRIPTION
The way the AWS provider minimum version was specified was causing version conflicts in my Terraform project. It is also using the deprecated method of declaring provider versions.

https://www.terraform.io/docs/language/providers/configuration.html#version-an-older-way-to-manage-provider-versions

The other change is the removal of the `S3` backend and `terraform` config block. Since this is a public module consumed by other terraform workspaces, terraform ignores the `S3` backend. In my particular case I don't use `S3` for state management and use a different backend.