### PR TITLE
Use empty string for template file variables for interpolation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_launch_configuration" "wireguard_launch_config" {
   iam_instance_profile = (var.use_eip ? aws_iam_instance_profile.wireguard_profile[0].name : null)
   user_data = templatefile("${path.module}/templates/user-data.txt", {
     wg_server_private_key              = var.use_ssm ? "AWS_SSM_PARAMETER" : var.wg_server_private_key,
-    wg_server_private_key_aws_ssm_name = var.use_ssm ? aws_ssm_parameter.wireguard_server_private_key[0].name : null,
+    wg_server_private_key_aws_ssm_name = var.use_ssm ? aws_ssm_parameter.wireguard_server_private_key[0].name : "",
     wg_server_net                      = var.wg_server_net,
     wg_server_port                     = var.wg_server_port,
     peers                              = join("\n", data.template_file.wg_client_data_json.*.rendered),


### PR DESCRIPTION
Use empty string for template file interpolation to avoid null error in terraform when rendering the `user-data.txt`. 

In this particular case since `use_ssm` is passed to the template and fails the bash condition, it doesn't really matter what the value of `wg_server_private_key_aws_ssm_name` because it would never be evaluated, but we set it to `""` to be logically as close to `null` as possible while making sure interpolation doesn't have a null value.

fixes #4 